### PR TITLE
Feature: Add Tasks

### DIFF
--- a/app/controllers/v1/projects_controller.rb
+++ b/app/controllers/v1/projects_controller.rb
@@ -22,7 +22,7 @@ module V1
       param :path, :id, :string, :required, 'User Id'
     end
     def show
-      project = Project.find_by params[:id]
+      project = Project.find_by id: params[:id]
       if project.present?
         render json: project
       else
@@ -51,7 +51,7 @@ module V1
       param :form, :description, :string, :optional, 'Project description'
     end
     def update
-      project = Project.find_by params[:id]
+      project = Project.find_by id: params[:id]
       if project.present? && project.update_attributes(project_params)
         render json: project
       elsif project.present?

--- a/app/controllers/v1/tasks_controller.rb
+++ b/app/controllers/v1/tasks_controller.rb
@@ -1,0 +1,67 @@
+module V1
+  class TasksController < ApplicationController
+    swagger_controller :tasks, 'Tasks'
+
+    before_action :load_project, except: :show
+
+    swagger_api :index do
+      summary 'List all tasks for a given project'
+      notes 'This lists all tasks (of every state)'
+      param :path, :project_id, :id, :required, 'Project Id'
+      param :query, :page, :integer, :optional, 'page number of results, default 1'
+      param :query, :page_size, :integer, :optional, 'number of results per page, default 25'
+    end
+    def index
+      tasks, errors = ListTasks.new(@project, index_params).call
+      if errors.any?
+        render json: { errors: errors }, status: 400
+      else
+        render json: tasks
+      end
+    end
+
+    swagger_api :show do
+      summary 'Fetch a single Task'
+      param :path, :id, :string, :required, 'Task Id'
+    end
+    def show
+      task = Task.find_by id: params[:id]
+      if task.present?
+        render json: task
+      else
+        render json: { errors: ['Task not found'] }, status: 404
+      end
+    end
+
+    swagger_api :create do
+      summary 'Creates a new Task'
+      param :path, :project_id, :id, :required, 'Project Id'
+      param :form, :name, :string, :required, 'Task designation'
+      param :form, :description, :string, :optional, 'Task description'
+    end
+    def create
+      task = @project.tasks.build task_params
+      if task.save
+        render json: task, status: 201
+      else
+        render json: { errors: task.errors.full_messages }, status: 400
+      end
+    end
+
+    private
+
+    def load_project
+      @project = Project.find params[:project_id]
+    rescue ActiveRecord::RecordNotFound
+      render json: { errors: ['Project was not found'] }, status: 404
+    end
+
+    def index_params
+      params.permit(:page, :page_size).to_h.symbolize_keys
+    end
+
+    def task_params
+      params.require(:task).permit :name, :description
+    end
+  end
+end

--- a/app/controllers/v1/tasks_controller.rb
+++ b/app/controllers/v1/tasks_controller.rb
@@ -12,7 +12,7 @@ module V1
       param :query, :page_size, :integer, :optional, 'number of results per page, default 25'
     end
     def index
-      tasks, errors = ListTasks.new(@project, index_params).call
+      tasks, errors = ListTasks.new(index_params).call
       if errors.any?
         render json: { errors: errors }, status: 400
       else
@@ -57,7 +57,7 @@ module V1
     end
 
     def index_params
-      params.permit(:page, :page_size).to_h.symbolize_keys
+      params.permit(:project_id, :page, :page_size).to_h.symbolize_keys
     end
 
     def task_params

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -15,6 +15,8 @@
 #
 
 class Project < ActiveRecord::Base
+  has_many :tasks
+
   validates :name, presence: true, uniqueness: true
   validates :state, presence: true
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,0 +1,34 @@
+# == Schema Information
+#
+# Table name: tasks
+#
+#  id          :uuid             not null, primary key
+#  name        :string           not null
+#  description :text
+#  state       :integer          default(15), not null
+#  project_id  :uuid             not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_tasks_on_name        (name) UNIQUE
+#  index_tasks_on_project_id  (project_id)
+#
+# Foreign Keys
+#
+#  fk_rails_02e851e3b7  (project_id => projects.id) ON DELETE => cascade
+#
+
+class Task < ActiveRecord::Base
+  belongs_to :project
+
+  validates :name, presence: true, uniqueness: true
+  validates :state, :project, presence: true
+
+  enum state: {
+    todo:          15,
+    "in-progress": 25,
+    done:          35
+  }
+end

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -1,0 +1,7 @@
+class ProjectSerializer < ActiveModel::Serializer
+
+  attributes :id, :name, :description, :state
+
+  has_many :tasks
+
+end

--- a/app/serializers/task_serializer.rb
+++ b/app/serializers/task_serializer.rb
@@ -1,0 +1,7 @@
+class TaskSerializer < ActiveModel::Serializer
+
+  attributes :id, :name, :description, :state
+
+  belongs_to :project_id
+
+end

--- a/app/serializers/v1/project_serializer.rb
+++ b/app/serializers/v1/project_serializer.rb
@@ -3,5 +3,6 @@ module V1
 
     attributes :id, :name, :description, :state
 
+    has_many :tasks
   end
 end

--- a/app/serializers/v1/project_serializer.rb
+++ b/app/serializers/v1/project_serializer.rb
@@ -1,8 +1,0 @@
-module V1
-  class ProjectSerializer < ActiveModel::Serializer
-
-    attributes :id, :name, :description, :state
-
-    has_many :tasks
-  end
-end

--- a/app/serializers/v1/task_serializer.rb
+++ b/app/serializers/v1/task_serializer.rb
@@ -1,8 +1,0 @@
-module V1
-  class TaskSerializer < ActiveModel::Serializer
-
-    attributes :id, :name, :description, :state
-
-    belongs_to :project_id
-  end
-end

--- a/app/serializers/v1/task_serializer.rb
+++ b/app/serializers/v1/task_serializer.rb
@@ -1,0 +1,8 @@
+module V1
+  class TaskSerializer < ActiveModel::Serializer
+
+    attributes :id, :name, :description, :state
+
+    belongs_to :project_id
+  end
+end

--- a/app/services/list_collection.rb
+++ b/app/services/list_collection.rb
@@ -44,7 +44,7 @@ class ListCollection
   end
 
   def serialized_collection
-    pager.results.map { |result| result_serializer.new(result).attributes }
+    pager.results.map { |result| result_serializer.new(result).as_json }
   end
 
   attr_reader :page, :page_size, :errors

--- a/app/services/list_projects.rb
+++ b/app/services/list_projects.rb
@@ -1,7 +1,7 @@
 class ListProjects < ListCollection
 
   attr_defaultable :project_respository, -> { Project }
-  attr_defaultable :result_serializer, -> { V1::ProjectSerializer }
+  attr_defaultable :result_serializer, -> { ProjectSerializer }
 
   def collection_type
     :projects

--- a/app/services/list_tasks.rb
+++ b/app/services/list_tasks.rb
@@ -3,9 +3,9 @@ class ListTasks < ListCollection
   attr_defaultable :task_repository, -> { @project.tasks }
   attr_defaultable :result_serializer, -> { TaskSerializer }
 
-  def initialize(project, page_options)
-    super page_options
-    @project = project
+  def initialize options
+    super page_options(options)
+    @project = Project.find options[:project_id]
   end
 
   def collection_type
@@ -14,5 +14,11 @@ class ListTasks < ListCollection
 
   def collection
     @tasks ||= task_repository
+  end
+
+  private
+
+  def page_options options
+    options.slice :page, :page_size
   end
 end

--- a/app/services/list_tasks.rb
+++ b/app/services/list_tasks.rb
@@ -1,0 +1,18 @@
+class ListTasks < ListCollection
+
+  attr_defaultable :task_repository, -> { @project.tasks }
+  attr_defaultable :result_serializer, -> { V1::TaskSerializer }
+
+  def initialize(project, page_options)
+    super page_options
+    @project = project
+  end
+
+  def collection_type
+    :tasks
+  end
+
+  def collection
+    @tasks ||= task_repository
+  end
+end

--- a/app/services/list_tasks.rb
+++ b/app/services/list_tasks.rb
@@ -1,7 +1,7 @@
 class ListTasks < ListCollection
 
   attr_defaultable :task_repository, -> { @project.tasks }
-  attr_defaultable :result_serializer, -> { V1::TaskSerializer }
+  attr_defaultable :result_serializer, -> { TaskSerializer }
 
   def initialize(project, page_options)
     super page_options

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,11 @@ Rails.application.routes.draw do
   crud = %i(index show create update destroy)
 
   namespace :v1 do
-    resources :projects, only: crud
+    resources :projects, only: crud do
+      resources :tasks, only: [:create, :index]
+      # Redirect more RESTful nested requests to /projects/:project_id/tasks/:task_id/ to /tasks/:task_id
+      get '/tasks/:id', to: redirect('/v1/tasks/%{id}')
+    end
+    resources :tasks, only: [:show]
   end
 end

--- a/db/migrate/20160710021520_create_tasks.rb
+++ b/db/migrate/20160710021520_create_tasks.rb
@@ -1,0 +1,15 @@
+class CreateTasks < ActiveRecord::Migration
+  def change
+    create_table :tasks, id: :uuid do |t|
+      t.string :name, null: false
+      t.index :name, unique: true
+      t.text :description
+      t.integer :state, null: false, default: 15
+      t.uuid :project_id, index: true, null: false
+
+      t.timestamps null: false
+    end
+
+    add_foreign_key :tasks, :projects, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160526161257) do
+ActiveRecord::Schema.define(version: 20160710021520) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,4 +27,17 @@ ActiveRecord::Schema.define(version: 20160526161257) do
 
   add_index "projects", ["name"], name: "index_projects_on_name", unique: true, using: :btree
 
+  create_table "tasks", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
+    t.string   "name",                     null: false
+    t.text     "description"
+    t.integer  "state",       default: 15, null: false
+    t.uuid     "project_id",               null: false
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
+  end
+
+  add_index "tasks", ["name"], name: "index_tasks_on_name", unique: true, using: :btree
+  add_index "tasks", ["project_id"], name: "index_tasks_on_project_id", using: :btree
+
+  add_foreign_key "tasks", "projects", on_delete: :cascade
 end

--- a/features/projects/list_projects.feature
+++ b/features/projects/list_projects.feature
@@ -71,7 +71,8 @@ Feature: Listing projects
             id: '54f8419c-3f22-4cba-b194-5f8b4727ccfd',
             name: 'Sample Project',
             description: 'A small sample project',
-            state: 'active'
+            state: 'active',
+            tasks: []
           }
         ],
         count: 1,

--- a/features/step_definitions/task_steps.rb
+++ b/features/step_definitions/task_steps.rb
@@ -18,5 +18,5 @@ Then(/^the project has (\d+) tasks?$/) do |count|
 end
 
 When(/^I request the tasks for that project$/) do
-  d.request_tasks @project, Hash.new
+  d.request_list "tasks", project_id: @project.id
 end

--- a/features/step_definitions/task_steps.rb
+++ b/features/step_definitions/task_steps.rb
@@ -1,0 +1,22 @@
+Given(/^a task:$/) do |table|
+  d.given_task table
+  @project = Project.find vertical_table(table)[:project_id]
+end
+
+When(/^I (?:try to )?create a task with:$/) do |table|
+  attributes = vertical_table table
+  d.create_task attributes
+  @project = Project.find attributes[:project_id]
+end
+
+Then(/^the project has the tasks:$/) do |table|
+  ActiveCucumber.diff_all! @project.tasks.order(:created_at), table
+end
+
+Then(/^the project has (\d+) tasks?$/) do |count|
+  expect(@project.tasks.count).to eq count.to_i
+end
+
+When(/^I request the tasks for that project$/) do
+  d.request_tasks @project, Hash.new
+end

--- a/features/support/world_drivers/api_world_driver.rb
+++ b/features/support/world_drivers/api_world_driver.rb
@@ -12,13 +12,12 @@ class ApiWorldDriver < WorldDriver
 
   def request_list collection_type, params
     result = get "/v1/#{collection_type}?#{params.to_query}"
-    body = JSON.parse(result.body).deep_symbolize_keys
-    if body[:errors].present?
-      @errors.push *body[:errors]
-      @results = nil
-    else
-      @results = body
-    end
+    parse_body result
+  end
+
+  def request_tasks project, params
+    result = get "/v1/projects/#{project.id}/tasks?#{params.to_query}"
+    parse_body result
   end
 
   def create_project attributes
@@ -29,4 +28,23 @@ class ApiWorldDriver < WorldDriver
     end
   end
 
+  def create_task attributes
+    result = post "/v1/projects/#{attributes[:project_id]}/tasks", { task: attributes }
+    body = JSON.parse(result.body).deep_symbolize_keys
+    if body[:errors].present?
+      @errors.push *body[:errors]
+    end
+  end
+
+  private
+
+  def parse_body result
+    body = JSON.parse(result.body).deep_symbolize_keys
+    if body[:errors].present?
+      @errors.push *body[:errors]
+      @results = nil
+    else
+      @results = body
+    end
+  end
 end

--- a/features/support/world_drivers/domain_world_driver.rb
+++ b/features/support/world_drivers/domain_world_driver.rb
@@ -10,11 +10,6 @@ class DomainWorldDriver < WorldDriver
     @errors.push *e
   end
 
-  def request_tasks project, params
-    @results, e = ListTasks.new(project, params).call
-    @errors.push *e
-  end
-
   def create_project params
     create_instance Project, params
   end

--- a/features/support/world_drivers/domain_world_driver.rb
+++ b/features/support/world_drivers/domain_world_driver.rb
@@ -10,9 +10,23 @@ class DomainWorldDriver < WorldDriver
     @errors.push *e
   end
 
-  def create_project params
-    project = Project.create params
-    @errors.push *project.errors.full_messages
+  def request_tasks project, params
+    @results, e = ListTasks.new(project, params).call
+    @errors.push *e
   end
 
+  def create_project params
+    create_instance Project, params
+  end
+
+  def create_task params
+    create_instance Task, params
+  end
+
+  private
+
+  def create_instance model, params
+    instance = model.create params
+    @errors.push *instance.errors.full_messages
+  end
 end

--- a/features/support/world_drivers/world_driver.rb
+++ b/features/support/world_drivers/world_driver.rb
@@ -22,6 +22,10 @@ class WorldDriver
     ActiveCucumber.create_one Project, data
   end
 
+  def given_task data
+    ActiveCucumber.create_one Task, data
+  end
+
   def check_unexpected_errors
     errors.present? && fail("Unexpected errors happened:\n #{errors.join("\n")}")
   end

--- a/features/tasks/create_tasks.feature
+++ b/features/tasks/create_tasks.feature
@@ -1,0 +1,31 @@
+@domain
+Feature: Creating tasks
+
+  Rules:
+  - A project must be specified
+  - Task name is required
+  - Created tasks should default to "todo" state
+
+  Background:
+    Given a project:
+      | ID          | 54f8419c-3f22-4cba-b194-5f8b4727ccfd |
+      | NAME        | Sample Project                       |
+      | DESCRIPTION | A small sample project               |
+      | STATE       | active                               |
+
+  Scenario: Creating a task with all fields
+    When I create a task with:
+      | NAME        | Sample Task                          |
+      | DESCRIPTION | This is a sample task                |
+      | PROJECT_ID  | 54f8419c-3f22-4cba-b194-5f8b4727ccfd |
+    Then the project has the tasks:
+      | NAME           | STATE  |
+      | Sample Task    | todo   |
+
+  Scenario: Trying to create a task without a name
+    When I try to create a task with:
+      | DESCRIPTION | This is a sample task                |
+      | PROJECT_ID  | 54f8419c-3f22-4cba-b194-5f8b4727ccfd |
+    Then the project has 0 tasks
+    And I get the error "Name can't be blank"
+

--- a/features/tasks/create_tasks.feature
+++ b/features/tasks/create_tasks.feature
@@ -1,4 +1,4 @@
-@domain
+@domain @api
 Feature: Creating tasks
 
   Rules:

--- a/features/tasks/list_tasks.feature
+++ b/features/tasks/list_tasks.feature
@@ -1,4 +1,4 @@
-@domain
+@domain @api
 Feature: Listing tasks
 
   Scenario: Verifying the format shape

--- a/features/tasks/list_tasks.feature
+++ b/features/tasks/list_tasks.feature
@@ -1,0 +1,32 @@
+@domain
+Feature: Listing tasks
+
+  Scenario: Verifying the format shape
+    Given a project:
+      | ID          | 54f8419c-3f22-4cba-b194-5f8b4727ccfd |
+      | NAME        | Sample Project                       |
+      | DESCRIPTION | A small sample project               |
+      | STATE       | active                               |
+    And a task:
+      | ID          | 5d2da7f9-e06e-4ac0-ab38-91fa48d455dc |
+      | NAME        | Sample Task                          |
+      | DESCRIPTION | This is a sample task                |
+      | PROJECT_ID  | 54f8419c-3f22-4cba-b194-5f8b4727ccfd |
+    When I request the tasks for that project
+    Then I get the data:
+      """
+      {
+        tasks: [
+          {
+            id: '5d2da7f9-e06e-4ac0-ab38-91fa48d455dc',
+            name: 'Sample Task',
+            description: 'This is a sample task',
+            project_id: '54f8419c-3f22-4cba-b194-5f8b4727ccfd',
+            state: 'todo'
+          }
+        ],
+        count: 1,
+        current_page_number: 1,
+        total_page_count: 1
+      }
+      """

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :task do
+    name
+    description 'A sample task'
+    project
+  end
+end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe Task, type: :model do
+  subject { FactoryGirl.build :task }
+  it { should validate_presence_of :name }
+  it { should validate_uniqueness_of :name }
+  it { should validate_presence_of :state }
+  it { should validate_presence_of :project }
+end


### PR DESCRIPTION
This PR adds support for Tasks as a subdivision of Projects. 

I generally tried to follow the lead of the codebase in adding this feature. There are a few places where I diverged slightly or had a question, so I've marked those places with comments in the PR for some discussion.

The biggest sticking point in my mind is the new `ListTasks` service. Since `Tasks` are scoped to a `Project`, it seemed natural that the `ListTasks` service be scoped to a particular project, similar to how the `ListProjects` service is scoped to `active` projects. ~~To have the additional context of a project, I have the new service taking a `project` as a parameter, and then just calling `super` to follow the old initialization path~~. However, this makes things a little awkward as now there is a divergence between the `initialize` methods of `ListProjects` and `ListTasks`. This came into play the most in testing, as I wasn't able to reuse the `request_list` methods in the world drivers. I tried to DRY up the code in those files a bit, but it still seems like there could be a more graceful solution there.

One way I could have avoided this would be to have the project-scoping be done in the `Tasks` controller. Then the two services would behave identically enough to be able to use the common methods in the world drivers. It seems wrong, though, to have the controller have knowledge of what scope of `tasks` it should return- some scoping would be done in the list services, and some more in the controller. The controller should just render what it's given.

(**Edit**: I actually took a break and came back with an idea for improving the `ListTasks` service- I just pushed up another commit, bec0c027, refactoring some of the code there and in the drivers. It's not perfect, but I think it's better, as the changes are now less disruptive and DRYer. I'm leaving it as a separate commit rather than rebasing the changes in for now, so hopefully the commits show a better path of how things than my rambling)

Other than that, this was my first experience using Cucumber for the majority of the testing, instead of RSpec. So I think there is some room for improvement there, particularly around passing variables between steps.

The solution that I arrived at has the `tasks` of a project being rendered as a child object in the JSON in both the `Project#index` and `Project#show` endpoints. I couldn't really see a Rails convention as far as how much information should be exposed in the parent and how much should only be exposed in the actual child endpoint.

I would love to hear any suggestions you guys have on these questions. This project helped me bump into some things I wasn't too sure of and run into some new questions. Thank you!
